### PR TITLE
Hide topics to follow box

### DIFF
--- a/content.css
+++ b/content.css
@@ -69,6 +69,11 @@
 	display: none !important;
 }
 
+/* Hide "Topics to follow" box */
+.bt--notopics [aria-label="Timeline: "] {
+        display: none !important;
+}
+
 /* Hide "Footer" box */
 .bt--nofooter [aria-label="footer" i] {
 	display: none !important;

--- a/prefs.js
+++ b/prefs.js
@@ -23,6 +23,10 @@ const DEFAULT_PREFS = {
     value: true,
     label: "Hide “Trends for you”",
   },
+  "bt--notopics": {
+    value: true,
+    label: "Hide “Topics to follow”",
+  },
   "bt--nowtf": {
     value: true,
     label: "Hide “Who to follow”",


### PR DESCRIPTION
This PR gives the user the ability to hide the "Topics to follow" box on Twitter.