### PR TITLE
Fix for "trending now" removing search bar

### DIFF
--- a/content.css
+++ b/content.css
@@ -65,7 +65,7 @@
 }
 
 /* Hide "Trends for you" box */
-.bt--notrends [aria-label*="trending" i] {
+.bt--notrends [aria-label*="timeline: trending now" i] {
 	display: none !important;
 }
 


### PR DESCRIPTION
Twitter changed the label of the parent container of both the search bar and the trending div to "trending", and renamed the trending label to "Timeline: Trending now".

I've tested this on Firefox 100.0.2

More details in https://github.com/oslego/better-twitter/issues/49