### PR TITLE
Fix bug where quote retweets aren't hidden

### DIFF
--- a/content.css
+++ b/content.css
@@ -86,6 +86,11 @@
   display: none !important;
 }
 
+/* Hide tweet quote retweet count */
+.bt--nopopularity [href$="/retweets/with_comments"] span {
+	display: none !important;
+}
+
 /* Hide tweet like count */
 .bt--nopopularity [data-testid="like"] span,
 .bt--nopopularity [data-testid="unlike"] span,


### PR DESCRIPTION
#27 Fixes the first problem where it fails to hide quoted retweets

Only added a new selector that references a `href` attribute which makes it specific enough not to overlap in the rest of the application

Quoted retweets are quite straightforward since they only show up on opened tweets, thus only the one selector was needed