### PR TITLE
Add x.com to manifest URLs

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -34,7 +34,9 @@
 			"run_at": "document_start",
 			"matches": [
 				"https://twitter.com/*",
-				"https://mobile.twitter.com/*"
+				"https://mobile.twitter.com/*",
+				"https://x.com/*",
+				"https://mobile.x.com/*"
 			],
 			"css": [
 				"content.css"


### PR DESCRIPTION
Twitter.com has started redirecting to x.com; for this extension to still work, x.com needs to be included in the URLs listed in manifest.json.